### PR TITLE
Example: Amazon S3, AWSv4 signature example

### DIFF
--- a/examples/amazon_s3/aws-signature-4-calculator/hmac-signature-example.js
+++ b/examples/amazon_s3/aws-signature-4-calculator/hmac-signature-example.js
@@ -1,0 +1,30 @@
+/**
+ * This file describes how the signature of AWS Signature Version 4 is calculated.
+ * The data presented here comes from the documentation:
+ * https://docs.aws.amazon.com/pt_br/AmazonS3/latest/API/sigv4-authentication-HTTPPOST.html
+ */
+
+const crypto = require('crypto');
+
+const SECRET_ACCESS_KEY = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+const date = '20151229';
+const awsRegion = 'us-east-1';
+
+const EXAMPLE_POLICY_BASE64 = 'eyAiZXhwaXJhdGlvbiI6ICIyMDE1LTEyLTMwVDEyOjAwOjAwLjAwMFoiLA0KICAiY29uZGl0aW9ucyI6IFsNCiAgICB7ImJ1Y2tldCI6ICJzaWd2NGV4YW1wbGVidWNrZXQifSwNCiAgICBbInN0YXJ0cy13aXRoIiwgIiRrZXkiLCAidXNlci91c2VyMS8iXSwNCiAgICB7ImFjbCI6ICJwdWJsaWMtcmVhZCJ9LA0KICAgIHsic3VjY2Vzc19hY3Rpb25fcmVkaXJlY3QiOiAiaHR0cDovL3NpZ3Y0ZXhhbXBsZWJ1Y2tldC5zMy5hbWF6b25hd3MuY29tL3N1Y2Nlc3NmdWxfdXBsb2FkLmh0bWwifSwNCiAgICBbInN0YXJ0cy13aXRoIiwgIiRDb250ZW50LVR5cGUiLCAiaW1hZ2UvIl0sDQogICAgeyJ4LWFtei1tZXRhLXV1aWQiOiAiMTQzNjUxMjM2NTEyNzQifSwNCiAgICB7IngtYW16LXNlcnZlci1zaWRlLWVuY3J5cHRpb24iOiAiQUVTMjU2In0sDQogICAgWyJzdGFydHMtd2l0aCIsICIkeC1hbXotbWV0YS10YWciLCAiIl0sDQoNCiAgICB7IngtYW16LWNyZWRlbnRpYWwiOiAiQUtJQUlPU0ZPRE5ON0VYQU1QTEUvMjAxNTEyMjkvdXMtZWFzdC0xL3MzL2F3czRfcmVxdWVzdCJ9LA0KICAgIHsieC1hbXotYWxnb3JpdGhtIjogIkFXUzQtSE1BQy1TSEEyNTYifSwNCiAgICB7IngtYW16LWRhdGUiOiAiMjAxNTEyMjlUMDAwMDAwWiIgfQ0KICBdDQp9';
+const EXPECTED_HMAC = '8afdbf4008c03f22c2cd3cdb72e4afbb1f6a588f3255ac628749a66d7f09699e';
+
+function hmacSHA256(signKey, text) {
+  return crypto.createHmac('sha256', signKey).update(text).digest();
+}
+
+function hmacSHA256Hex(signKey, text) {
+  return crypto.createHmac('sha256', signKey).update(text).digest('hex');
+}
+
+let signingKey = hmacSHA256('AWS4' + SECRET_ACCESS_KEY, date);
+signingKey = hmacSHA256(signingKey, awsRegion);
+signingKey = hmacSHA256(signingKey, 's3');
+signingKey = hmacSHA256(signingKey, 'aws4_request');
+
+const outputHmac = hmacSHA256Hex(signingKey, EXAMPLE_POLICY_BASE64);
+console.log(outputHmac === EXPECTED_HMAC); // this should be true

--- a/examples/amazon_s3/aws-signature-4-calculator/package.json
+++ b/examples/amazon_s3/aws-signature-4-calculator/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "aws-signature-4-calculator",
+  "version": "1.0.0",
+  "description": "A NodeJS that shows how to calculate AWS POST signature",
+  "main": "hmac-signature-example",
+  "dependencies": {},
+  "devDependencies": {},
+  "keywords": [
+    "aws",
+    "signature",
+    "hmac",
+    "sha256"
+  ],
+  "author": "Raphael Brandão",
+  "license": "ISC"
+}


### PR DESCRIPTION
# Description

Add simple node package to exemplify the processing of generating the signature key of AWSv4, as described here:

![image](https://user-images.githubusercontent.com/11169832/66262549-fc09a500-e7b8-11e9-8ede-f20defeeb8bf.png)
https://docs.aws.amazon.com/pt_br/AmazonS3/latest/API/sigv4-authentication-HTTPPOST.html
