### PR TITLE
Add VSCode workspace file

### DIFF
--- a/ESP32-Cam-AI-Thinker_Examples.code-workspace
+++ b/ESP32-Cam-AI-Thinker_Examples.code-workspace
@@ -1,0 +1,25 @@
+{
+  "folders": [
+    {
+      "path": "."
+    },
+    {
+      "path": "examples\\sd_jpg"
+    },
+    {
+      "path": "examples\\change_detection"
+    },
+    {
+      "path": "examples\\google_storage"
+    },
+    {
+      "path": "examples\\http_jpg"
+    }
+  ],
+  "settings": {},
+  "extensions": {
+    "recommendations": [
+      "platformio.platformio-ide"
+    ]
+  }
+}


### PR DESCRIPTION
# Description

Whenever the project folder is opened on VSCode, a box will prompt to open the workspace (attachment 1).

The workspace is configured in such a way that each example is a folder inside the workspace.

## Attachments

- Attachment 1, the VSCode prompt to open the workspace:
![image](https://user-images.githubusercontent.com/11169832/87861270-0dbcd300-c91b-11ea-98ad-246fe2d77a11.png)

- Attachment 2, the Workspace with examples
![image](https://user-images.githubusercontent.com/11169832/87861281-2b8a3800-c91b-11ea-8dc2-aee877c88d09.png)
