### PR TITLE
Fix memory allocation on google_storage example

### DIFF
--- a/examples/google_storage/lib/google_api/src/gcp_auth_get_device_code.c
+++ b/examples/google_storage/lib/google_api/src/gcp_auth_get_device_code.c
@@ -12,8 +12,10 @@ void gcp_auth_get_device_code()
 {
   ESP_LOGI(TAG, "Get device token...");
 
-  char *post_data = malloc(143);
-  sprintf(post_data, "scope=https://www.googleapis.com/auth/devstorage.read_write&client_id=%s", CONFIG_GCP_CLIENT_ID);
+  char *BODY = "scope=https://www.googleapis.com/auth/devstorage.read_write&client_id=%s";
+  int body_len = strlen(BODY) + strlen(CONFIG_GCP_CLIENT_ID) + 1;
+  char *post_data = malloc(body_len);
+  snprintf(post_data, body_len, BODY, CONFIG_GCP_CLIENT_ID);
 
   esp_http_client_config_t config = {
       .url = "https://accounts.google.com/o/oauth2/device/code",

--- a/examples/google_storage/lib/google_api/src/gcp_auth_get_token.c
+++ b/examples/google_storage/lib/google_api/src/gcp_auth_get_token.c
@@ -12,8 +12,11 @@ void gcp_auth_get_token()
 {
   ESP_LOGI(TAG, "Get auth token...");
 
-  char *post_data = malloc(512);
-  sprintf(post_data, "grant_type=http://oauth.net/grant_type/device/1.0&client_id=%s&client_secret=%s&code=%s",
+  char *BODY = "grant_type=urn:ietf:params:oauth:grant-type:device_code&client_id=%s&client_secret=%s&code=%s";
+  int body_len = strlen(BODY) + strlen(CONFIG_GCP_CLIENT_ID) + strlen(CONFIG_GCP_CLIENT_SECRET) + strlen(CONFIG_GCP_DEVICE_CODE) + 1;
+  char *post_data = malloc(body_len);
+  snprintf(post_data, body_len,
+          BODY,
           CONFIG_GCP_CLIENT_ID,
           CONFIG_GCP_CLIENT_SECRET,
           CONFIG_GCP_DEVICE_CODE);

--- a/examples/google_storage/lib/google_api/src/gcp_auth_refresh_token.c
+++ b/examples/google_storage/lib/google_api/src/gcp_auth_refresh_token.c
@@ -34,8 +34,11 @@ esp_err_t gcp_auth_refresh_token()
 {
   ESP_LOGI(TAG, "Refresh auth token...");
 
-  char *post_data = malloc(256);
-  sprintf(post_data, "grant_type=refresh_token&client_id=%s&client_secret=%s&refresh_token=%s",
+  char *BODY = "grant_type=refresh_token&client_id=%s&client_secret=%s&refresh_token=%s";
+  int body_len = strlen(BODY) + strlen(CONFIG_GCP_CLIENT_ID) + strlen(CONFIG_GCP_CLIENT_SECRET) + strlen(CONFIG_GCP_REFRESH_TOKEN) + 1;
+  char *post_data = malloc(body_len);
+  snprintf(post_data, body_len,
+          BODY,
           CONFIG_GCP_CLIENT_ID,
           CONFIG_GCP_CLIENT_SECRET,
           CONFIG_GCP_REFRESH_TOKEN);

--- a/examples/google_storage/lib/google_api/src/gcp_check_bucket_access.c
+++ b/examples/google_storage/lib/google_api/src/gcp_check_bucket_access.c
@@ -23,11 +23,15 @@ esp_err_t gcp_check_bucket_access()
 {
   ESP_LOGI(TAG, "Checking bucket access [%s]...", CONFIG_GCP_BUCKET);
 
-  char *post_url = malloc(256);
-  sprintf(post_url, "https://www.googleapis.com/storage/v1/b?project=%s&maxResults=1&prefix=%s", CONFIG_GCP_PROJECT, CONFIG_GCP_BUCKET);
+  char *URL = "https://www.googleapis.com/storage/v1/b?project=%s&maxResults=1&prefix=%s";
+  int post_url_len = strlen(URL) + strlen(CONFIG_GCP_PROJECT) + strlen(CONFIG_GCP_BUCKET) + 1;
+  char *post_url = malloc(post_url_len);
+  snprintf(post_url, post_url_len, URL, CONFIG_GCP_PROJECT, CONFIG_GCP_BUCKET);
 
-  char *authorization = malloc(256);
-  sprintf(authorization, "Bearer %s", ACCESS_TOKEN);
+  char *AUTH_VALUE = "Bearer %s";
+  int auth_len = strlen(AUTH_VALUE) + strlen(ACCESS_TOKEN) + 1;
+  char *authorization = malloc(auth_len);
+  snprintf(authorization, auth_len, AUTH_VALUE, ACCESS_TOKEN);
 
   esp_http_client_config_t config = {
       .url = post_url,

--- a/examples/google_storage/lib/google_api/src/gcp_storage_insert_object.c
+++ b/examples/google_storage/lib/google_api/src/gcp_storage_insert_object.c
@@ -24,8 +24,9 @@ esp_err_t gcp_storage_insert_object(const char *pic_name, const char *binary, si
   ESP_LOGI(TAG, "Insert object [%s] in bucket [%s]...", pic_name, CONFIG_GCP_BUCKET);
 
   const char *URL = "https://www.googleapis.com/upload/storage/v1/b/%s/o?uploadType=media&name=%s";
-  char *post_url = malloc(strlen(URL) + strlen(CONFIG_GCP_BUCKET) + strlen(pic_name));
-  sprintf(post_url, URL, CONFIG_GCP_BUCKET, pic_name);
+  int post_url_len = strlen(URL) + strlen(CONFIG_GCP_BUCKET) + strlen(pic_name) + 1;
+  char *post_url = malloc(post_url_len);
+  snprintf(post_url, post_url_len, URL, CONFIG_GCP_BUCKET, pic_name);
 
   esp_http_client_config_t config = {
       .url = post_url,

--- a/examples/google_storage/src/main.c
+++ b/examples/google_storage/src/main.c
@@ -68,8 +68,17 @@ static void take_picture_and_upload_to_google_storage()
   time_t now = 0;
   time(&now);
   localtime_r(&now, &timeinfo);
-  char *pic_name = malloc(sizeof("YYYY-mm-dd_hh-MM-ss.jpg"));
-  sprintf(pic_name, "%04d-%02d-%02d_%02d-%02d-%02d.jpg", timeinfo.tm_year + 1900, timeinfo.tm_mon + 1, timeinfo.tm_mday, timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec);
+  int pic_name_len = 76;
+  char *pic_name = malloc(pic_name_len);
+  snprintf(pic_name, pic_name_len,
+    "%04d-%02d-%02d_%02d-%02d-%02d.jpg",
+    timeinfo.tm_year + 1900,
+    timeinfo.tm_mon + 1,
+    timeinfo.tm_mday,
+    timeinfo.tm_hour,
+    timeinfo.tm_min,
+    timeinfo.tm_sec
+  );
 
   ESP_LOGI(TAG, "Picture %s taken.", pic_name);
   ESP_LOGI(TAG, "Uploading %s...", pic_name);
@@ -97,7 +106,6 @@ static void task_gcp()
   while (1)
   {
     EventBits_t bit = xEventGroupWaitBits(eventGroup, (WIFI_CONNECTED | SYNC_NTP | HAS_AUTH_TOKEN), false, false, portMAX_DELAY);
-    esp_err_t err;
 
     if (bit == WIFI_CONNECTED)
     {


### PR DESCRIPTION
# Description

This PR changes how the malloc allocation size is calculated. It now concatenates `strlen`s of all variables that composes the `sprinft` value. 